### PR TITLE
fix(actions): code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Potential fix for [https://github.com/flare-foundation/flare-ai-kit/security/code-scanning/2](https://github.com/flare-foundation/flare-ai-kit/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the provided workflow, it primarily involves checking out the repository and running tests, so `contents: read` should suffice. If additional permissions are required later, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
