### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Potential fix for [https://github.com/flare-foundation/flare-ai-kit/security/code-scanning/1](https://github.com/flare-foundation/flare-ai-kit/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. Since the workflow only performs linting and type-checking, it likely only needs read access to the repository contents. The `permissions` block should be set to `contents: read` to minimize access. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
